### PR TITLE
[GOORM-5]- 기숙사 정보 반환 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/goormthon3/team49/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/goormthon3/team49/common/domain/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.goormthon3.team49.common.domain;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/com/goormthon3/team49/common/exception/CustomException.java
+++ b/src/main/java/com/goormthon3/team49/common/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.goormthon3.team49.common.exception;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ExceptionCode code;
+
+    public CustomException(ExceptionCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+
+    public boolean isServerError() {
+        return code.getStatus().equals(INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/goormthon3/team49/common/exception/ExceptionCode.java
+++ b/src/main/java/com/goormthon3/team49/common/exception/ExceptionCode.java
@@ -1,0 +1,10 @@
+package com.goormthon3.team49.common.exception;
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+    HttpStatus getStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/goormthon3/team49/common/exception/ExceptionResponse.java
+++ b/src/main/java/com/goormthon3/team49/common/exception/ExceptionResponse.java
@@ -1,0 +1,38 @@
+package com.goormthon3.team49.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.Builder;
+
+public record ExceptionResponse(@JsonIgnore HttpStatus status, String code, String message) {
+
+    @Builder
+    public ExceptionResponse {
+    }
+
+    public static ExceptionResponse from(CustomException exception) {
+        return ExceptionResponse.builder()
+                .status(exception.getCode().getStatus())
+                .code(exception.getCode().getCode())
+                .message(exception.getCode().getMessage())
+                .build();
+    }
+
+    public static ExceptionResponse from(ExceptionCode code) {
+        return ExceptionResponse.builder()
+                .status(code.getStatus())
+                .code(code.getCode())
+                .message(code.getMessage())
+                .build();
+    }
+
+    public static ExceptionResponse of(HttpStatus status, String code, String message) {
+        return ExceptionResponse.builder()
+                .status(status)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon3/team49/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/com/goormthon3/team49/common/exception/GlobalExceptionCode.java
@@ -1,0 +1,26 @@
+package com.goormthon3.team49.common.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalExceptionCode implements ExceptionCode{
+    INVALID_INPUT(BAD_REQUEST, "유효한 입력 형식이 아닙니다."),
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "예상치 못한 문제가 발생했습니다.");
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+
+}

--- a/src/main/java/com/goormthon3/team49/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goormthon3/team49/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.goormthon3.team49.common.exception;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.goormthon3.team49.common.exception.GlobalExceptionCode.INVALID_INPUT;
+import static com.goormthon3.team49.common.exception.GlobalExceptionCode.SERVER_ERROR;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    private final ApplicationEventPublisher eventPublisher;
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ExceptionResponse> handleCustomException(CustomException exception) {
+        if (exception.isServerError())
+            eventPublisher.publishEvent(exception);
+        ExceptionResponse response = ExceptionResponse.from(exception);
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
+        eventPublisher.publishEvent(exception);
+        return ResponseEntity.internalServerError().body(ExceptionResponse.from(SERVER_ERROR));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException exception,
+                                                                            HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        String message = exception.getAllValidationResults().stream()
+                .map(ParameterValidationResult::getResolvableErrors)
+                .flatMap(List::stream)
+                .map(MessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        ExceptionResponse response = ExceptionResponse.of(INVALID_INPUT.getStatus(), INVALID_INPUT.getCode(), message);
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException exception,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        String message = exception.getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        ExceptionResponse response = ExceptionResponse.of(INVALID_INPUT.getStatus(), INVALID_INPUT.getCode(), message);
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/application/CommentService.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/application/CommentService.java
@@ -1,0 +1,37 @@
+package com.goormthon3.team49.domain.comment.application;
+
+import com.goormthon3.team49.domain.comment.domain.Comment;
+import com.goormthon3.team49.domain.comment.domain.CommentRepository;
+import com.goormthon3.team49.domain.comment.presentation.request.CommentRequest;
+import com.goormthon3.team49.domain.comment.presentation.response.CommentListResponse;
+import com.goormthon3.team49.domain.comment.presentation.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Comments;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long product_id, CommentRequest request) {
+        Long user_id = 1L; //UserDetailService 생성되면 로직 업데이트 예정
+        String username="홍길동"; //UserDetailService 생성되면 로직 업데이트 예정
+        Comment comment=Comment.create(request.content(),user_id,username,product_id);
+        commentRepository.save(comment).getId();
+        return CommentResponse.of(comment);
+    }
+
+    @Transactional
+    public CommentListResponse getComment(Long product_id) {
+        List<Comment> comments=commentRepository.findByProductId(product_id);
+        Long comment_count=Long.valueOf(comments.size());
+        return CommentListResponse.of(product_id,comment_count,comments);
+    }
+
+
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/domain/Comment.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/domain/Comment.java
@@ -1,0 +1,41 @@
+package com.goormthon3.team49.domain.comment.domain;
+
+import com.goormthon3.team49.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 2000)
+    private String content;
+
+    @Column(nullable = false)
+    private Long user_id;
+
+    @Column(nullable = false, length = 2000)
+    private String username;
+
+    @Column(nullable = false)
+    private Long productId;
+
+    public static Comment create(String content, Long user_id, String username, Long product_id) {
+        return Comment.builder()
+                .content(content)
+                .user_id(user_id)
+                .username(username)
+                .productId(product_id)
+                .build();
+    }
+
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/domain/CommentRepository.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/domain/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.goormthon3.team49.domain.comment.domain;
+
+import java.util.List;
+
+public interface CommentRepository {
+    Comment save(Comment comment);
+    List<Comment> findByProductId(Long productId);
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/infrastucture/CommentRepositoryImpl.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/infrastucture/CommentRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.goormthon3.team49.domain.comment.infrastucture;
+
+import com.goormthon3.team49.domain.comment.domain.Comment;
+import com.goormthon3.team49.domain.comment.domain.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepository {
+    private final JpaCommentRepository jpaCommentRepository;
+
+    @Override
+    public Comment save(Comment comment) {
+        return jpaCommentRepository.save(comment);
+    }
+
+    @Override
+    public List<Comment> findByProductId(Long product_id) {
+        return jpaCommentRepository.findByProductId(product_id);
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/infrastucture/JpaCommentRepository.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/infrastucture/JpaCommentRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon3.team49.domain.comment.infrastucture;
+
+import com.goormthon3.team49.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaCommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByProductId(Long productId);
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/presentation/CommentController.java
@@ -1,0 +1,39 @@
+package com.goormthon3.team49.domain.comment.presentation;
+
+import com.goormthon3.team49.domain.comment.application.CommentService;
+import com.goormthon3.team49.domain.comment.presentation.request.CommentRequest;
+import com.goormthon3.team49.domain.comment.presentation.response.CommentListResponse;
+import com.goormthon3.team49.domain.comment.presentation.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+public class CommentController {
+    private final CommentService commentService;
+
+    @ResponseStatus(CREATED)
+    @PostMapping("/{productId}/createComment")
+    public ResponseEntity<CommentResponse> createReview(
+            @PathVariable Long productId,
+             @RequestBody CommentRequest request
+    ) {
+        CommentResponse response = commentService.createComment(productId,request);
+        return ResponseEntity.status(CREATED).body(response);
+    }
+
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<CommentListResponse> getReview(
+            @PathVariable Long productId
+    ) {
+        CommentListResponse response = commentService.getComment(productId);
+        return ResponseEntity.status(OK).body(response);
+    }
+
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/presentation/request/CommentRequest.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/presentation/request/CommentRequest.java
@@ -1,0 +1,7 @@
+package com.goormthon3.team49.domain.comment.presentation.request;
+
+public record CommentRequest(String content) {
+    public static CommentRequest of(String content) {
+        return new CommentRequest(content);
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/presentation/response/CommentListResponse.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/presentation/response/CommentListResponse.java
@@ -1,0 +1,22 @@
+package com.goormthon3.team49.domain.comment.presentation.response;
+
+import com.goormthon3.team49.domain.comment.domain.Comment;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record CommentListResponse(
+        Long product_id,
+        Long comment_count,
+        List<CommentResponse> comments
+) {
+    public static CommentListResponse of(Long product_id,Long comment_count,List<Comment> comments) {
+        return CommentListResponse.builder()
+                .product_id(product_id)
+                .comment_count(comment_count)
+                .comments(comments.stream()
+                        .map(CommentResponse::of)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/comment/presentation/response/CommentResponse.java
+++ b/src/main/java/com/goormthon3/team49/domain/comment/presentation/response/CommentResponse.java
@@ -1,0 +1,28 @@
+package com.goormthon3.team49.domain.comment.presentation.response;
+
+import com.goormthon3.team49.domain.comment.domain.Comment;
+import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.format.DateTimeFormatter;
+
+@Builder
+public record CommentResponse(
+        Long comment_id,
+        Long user_id,
+        String username,
+        String content,
+        @DateTimeFormat(pattern="yyyy-MM-dd")
+        String createdAt
+) {
+    public static CommentResponse of(Comment comment) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return CommentResponse.builder()
+                .comment_id(comment.getId())
+                .user_id(comment.getUser_id())
+                .username(comment.getUsername())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt().format(formatter))
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/application/SchoolService.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/application/SchoolService.java
@@ -33,7 +33,7 @@ public class SchoolService {
         }
 
         if (closestSchool == null) {
-            throw new SchoolNotFoundException("반경 " + RADIUS + "km 내에 학교가 없습니다.");
+            throw new SchoolNotFoundException();
         }
 
         return SchoolResponse.of(closestSchool.getSchoolName());

--- a/src/main/java/com/goormthon3/team49/domain/school/application/SchoolService.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/application/SchoolService.java
@@ -1,0 +1,76 @@
+package com.goormthon3.team49.domain.school.application;
+
+import com.goormthon3.team49.domain.school.domain.School;
+import com.goormthon3.team49.domain.school.domain.SchoolRepository;
+import com.goormthon3.team49.domain.school.presentation.exception.SchoolNotFoundException;
+import com.goormthon3.team49.domain.school.presentation.response.SchoolResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SchoolService {
+    private final SchoolRepository schoolRepository;
+
+    private static final double RADIUS = 10.0; // 반경 10km
+
+    public SchoolResponse findClosestSchool(BigDecimal userLatitude, BigDecimal userLongitude) {
+        List<School> schools = schoolRepository.findAll();
+
+        School closestSchool = null;
+        double minDistance = Double.MAX_VALUE;
+
+        for (School school : schools) {
+            Double distance = calculateDistance(userLatitude, userLongitude, school.getLatitude(), school.getLongitude());
+
+            if (distance <= RADIUS && distance < minDistance) {
+                minDistance = distance;
+                closestSchool = school;
+            }
+        }
+
+        if (closestSchool == null) {
+            throw new SchoolNotFoundException("반경 " + RADIUS + "km 내에 학교가 없습니다.");
+        }
+
+        return SchoolResponse.of(closestSchool.getSchoolName());
+    }
+
+    private double calculateDistance(BigDecimal lat1, BigDecimal lon1, BigDecimal lat2, BigDecimal lon2) {
+        final int EARTH_RADIUS = 6371; // Radius in kilometers
+
+        MathContext mc = MathContext.DECIMAL64;
+
+        BigDecimal dLat = toRadians(lat2.subtract(lat1, mc), mc);
+        BigDecimal dLon = toRadians(lon2.subtract(lon1, mc), mc);
+
+        BigDecimal sinDLat = BigDecimal.valueOf(Math.sin(dLat.doubleValue()));
+        BigDecimal sinDLon = BigDecimal.valueOf(Math.sin(dLon.doubleValue()));
+
+        BigDecimal a = sinDLat.multiply(sinDLat, mc)
+                .add(
+                        cos(toRadians(lat1, mc), mc).multiply(
+                                cos(toRadians(lat2, mc), mc), mc
+                        ).multiply(
+                                sinDLon.multiply(sinDLon, mc), mc
+                        ), mc
+                );
+
+        BigDecimal c = BigDecimal.valueOf(2).multiply(
+                BigDecimal.valueOf(Math.atan2(Math.sqrt(a.doubleValue()), Math.sqrt(1 - a.doubleValue()))), mc
+        );
+
+        return EARTH_RADIUS * c.doubleValue(); // Distance in kilometers
+    }
+
+    private BigDecimal toRadians(BigDecimal value, MathContext mc) {
+        return value.multiply(BigDecimal.valueOf(Math.PI), mc).divide(BigDecimal.valueOf(180), mc);
+    }
+
+    private BigDecimal cos(BigDecimal radians, MathContext mc) {
+        return BigDecimal.valueOf(Math.cos(radians.doubleValue()));
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/domain/School.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/domain/School.java
@@ -1,0 +1,34 @@
+package com.goormthon3.team49.domain.school.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class School {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 2000)
+    private String schoolName;
+
+    @Column(precision = 9, scale = 6)
+    private BigDecimal latitude;
+
+    @Column(precision = 9, scale = 6)
+    private BigDecimal longitude;
+
+
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/domain/SchoolRepository.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/domain/SchoolRepository.java
@@ -1,0 +1,7 @@
+package com.goormthon3.team49.domain.school.domain;
+
+import java.util.List;
+
+public interface SchoolRepository {
+    List<School> findAll();
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/infrastructure/JpaSchoolRepository.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/infrastructure/JpaSchoolRepository.java
@@ -1,0 +1,7 @@
+package com.goormthon3.team49.domain.school.infrastructure;
+
+import com.goormthon3.team49.domain.school.domain.School;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaSchoolRepository extends JpaRepository<School, Long> {
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/infrastructure/SchoolRepositoryImpl.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/infrastructure/SchoolRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.goormthon3.team49.domain.school.infrastructure;
+
+import com.goormthon3.team49.domain.school.domain.School;
+import com.goormthon3.team49.domain.school.domain.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SchoolRepositoryImpl implements SchoolRepository {
+    private final JpaSchoolRepository jpaschoolRepository;
+
+    @Override
+    public List<School> findAll(){
+        return jpaschoolRepository.findAll();
+    }// 모든 학교 데이터 조회
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/presentation/SchoolController.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/presentation/SchoolController.java
@@ -1,0 +1,27 @@
+package com.goormthon3.team49.domain.school.presentation;
+
+import com.goormthon3.team49.domain.school.application.SchoolService;
+import com.goormthon3.team49.domain.school.presentation.response.SchoolResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/schools")
+public class SchoolController {
+    private final SchoolService schoolService;
+    @GetMapping
+    public ResponseEntity<SchoolResponse> getSchoolsByLocation(
+            @RequestParam BigDecimal latitude,
+            @RequestParam BigDecimal longitude) {
+        SchoolResponse response = schoolService.findClosestSchool(latitude, longitude);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/presentation/exception/SchoolExceptionCode.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/presentation/exception/SchoolExceptionCode.java
@@ -1,0 +1,22 @@
+package com.goormthon3.team49.domain.school.presentation.exception;
+
+import com.goormthon3.team49.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum SchoolExceptionCode implements ExceptionCode {
+    SCHOOL_NOT_FOUND(NOT_FOUND, "반경 10KM 내의 기숙사를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/goormthon3/team49/domain/school/presentation/exception/SchoolNotFoundException.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/presentation/exception/SchoolNotFoundException.java
@@ -1,8 +1,12 @@
 package com.goormthon3.team49.domain.school.presentation.exception;
 
-public class SchoolNotFoundException extends RuntimeException {
-    public SchoolNotFoundException(String message) {
-        super(message);
+
+import com.goormthon3.team49.common.exception.CustomException;
+import static com.goormthon3.team49.domain.school.presentation.exception.SchoolExceptionCode.SCHOOL_NOT_FOUND;
+
+public class SchoolNotFoundException extends CustomException {
+    public SchoolNotFoundException() {
+        super(SCHOOL_NOT_FOUND);
     }
 }
 

--- a/src/main/java/com/goormthon3/team49/domain/school/presentation/exception/SchoolNotFoundException.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/presentation/exception/SchoolNotFoundException.java
@@ -1,0 +1,8 @@
+package com.goormthon3.team49.domain.school.presentation.exception;
+
+public class SchoolNotFoundException extends RuntimeException {
+    public SchoolNotFoundException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/goormthon3/team49/domain/school/presentation/response/SchoolResponse.java
+++ b/src/main/java/com/goormthon3/team49/domain/school/presentation/response/SchoolResponse.java
@@ -1,0 +1,10 @@
+package com.goormthon3.team49.domain.school.presentation.response;
+
+import lombok.Builder;
+
+@Builder
+public record SchoolResponse(String school) {
+    public static SchoolResponse of(String school) {
+        return new SchoolResponse(school);
+    }
+}


### PR DESCRIPTION
- 반경 10km 이내의 기숙사 정보를 반환하도록 하였습니다.
- 예외 처리 로직을 추가했습니다. 
- 다른 도메인에서도 사용할 수 있는 공통 예외 처리 클래스를 common 폴더에 두었습니다.
![Screenshot 2024-11-21 at 2 34 06 AM](https://github.com/user-attachments/assets/33456183-d7e6-4616-8a4d-b5a79cb355ae)
![Screenshot 2024-11-21 at 2 14 48 AM](https://github.com/user-attachments/assets/6c2b4e3d-642d-41da-8552-806af8dcb2b8)
![Screenshot 2024-11-21 at 2 13 40 AM](https://github.com/user-attachments/assets/859dc975-55e7-4b3b-9733-bc76e2be7681)

