### PR TITLE
[GOORM-2]-유저 테이블의 profileId 컬럼 profile_image_uri 컬럼으로 변경

### DIFF
--- a/src/main/java/com/goormthon3/team49/domain/user/domain/User.java
+++ b/src/main/java/com/goormthon3/team49/domain/user/domain/User.java
@@ -40,8 +40,8 @@ public class User {
     @Column(updatable = false)
     private Timestamp createdAt;
 
-    @Column(nullable = false)
-    private Long profileId;     //user_image table implementation and modification required
+    @Column(length = 255)
+    private String profileImageUri;
 
     @PrePersist
     public void prePersist() {


### PR DESCRIPTION
- user_image 테이블의 용도가 불필요해져서 해당 테이블 삭제
- 유저의 카카오 프로필 이미지를 바로 User 테이블에 저장 
- 아래의 사진과 같이 ERD 변경

![image](https://github.com/user-attachments/assets/195c7bc6-e001-44c5-b143-b64de0b8071d)
